### PR TITLE
chore: establish mandates and PR-only workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# hush 🛡️ Mandates
+
+## Development Workflow
+- **PR-Only Pushes:** All code changes, documentation updates, and asset additions MUST be submitted via a Pull Request. Direct pushes to the `master` branch are strictly prohibited.
+- **Verification:** Every PR must pass all existing tests (`npm test`) and maintain or improve the current test coverage before merging.
+- **Security First:** Never bypass security protocols (like `HUSH_AUTH_TOKEN` or local binding) during development or testing.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,6 @@
+# Mandates
+
+All foundational mandates for this project are maintained in [CLAUDE.md](./CLAUDE.md).
+
+1. All code changes MUST be submitted via Pull Request.
+2. NO direct pushes to `master`.


### PR DESCRIPTION
Adds CLAUDE.md and GEMINI.md to enforce PR-only pushes going forward.