### PR TITLE
docs: config-file-first setup — no env vars needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,55 +3,18 @@
 </p>
 
 **hush** is a Semantic Security Gateway for AI agents.
-It acts as a local proxy between your AI tools (Claude Code, Codex, OpenCode, Gemini CLI) and LLM providers (Anthropic, OpenAI, ZhipuAI, Google).
+It sits between your AI tools (Claude Code, Codex, OpenCode, Gemini CLI) and LLM providers, ensuring that sensitive data — emails, IP addresses, API keys, credit cards — never leaves your machine.
 
-Hush ensures that sensitive data — emails, IP addresses, API keys, credit cards — never leaves your machine by redacting it from prompts and tool outputs before they hit the cloud.
-
-## Supported Tools
-
-| Tool | Provider | Auth | Route |
-|------|----------|------|-------|
-| Claude Code | Anthropic | API key (`x-api-key`) | `/v1/messages` |
-| Codex | OpenAI | Bearer token | `/v1/chat/completions` |
-| OpenCode | ZhipuAI (GLM-5) | Bearer token | `/api/paas/v4/**`, `/api/coding/paas/v4/**` |
-| Gemini CLI | Google | API key (`x-goog-api-key`) | `/v1beta/models/**` |
-| Any tool | Auto-detect | Passthrough | `/*` (catch-all) |
-
-## Quick Start (Dev Machine)
-
-### 1. Clone and build
+## Quick Start
 
 ```bash
-git clone https://github.com/aictrl-dev/hush.git
-cd hush
-npm install
-npm run build
+npm install -g @aictrl/hush
+hush
 ```
 
-### 2. Start the gateway
+Hush starts on `http://127.0.0.1:4000`. Now point your AI tool at it:
 
-```bash
-# Terminal 1 — start hush on port 4000 (default)
-npm start
-
-# Or with the live dashboard:
-npm start -- --dashboard
-
-# Or pick a custom port:
-PORT=3005 npm start
-```
-
-You should see:
-```
-Hush Semantic Gateway is listening on http://localhost:4000
-Routes: /v1/messages → Anthropic, /v1/chat/completions → OpenAI, /api/paas/v4/** → ZhipuAI, * → Google
-```
-
-### 3. Point your AI tool at the gateway
-
-The gateway handles all providers simultaneously — no restart needed. You only need to tell each tool to send requests to `http://127.0.0.1:4000` instead of the provider's API. Hush forwards your existing auth headers transparently — no API keys need to be reconfigured.
-
-#### Claude Code
+### Claude Code
 
 Add to `~/.claude/settings.json`:
 
@@ -63,26 +26,22 @@ Add to `~/.claude/settings.json`:
 }
 ```
 
-Then run `claude` as normal.
+> **Note:** Claude Code subscription (OAuth) tokens are currently blocked by Anthropic for third-party proxies ([anthropics/claude-code#28091](https://github.com/anthropics/claude-code/issues/28091)). If you hit a 401, add `"ANTHROPIC_AUTH_TOKEN": "sk-ant-..."` to the env block above.
 
-> **Note:** Claude Code subscription (OAuth) tokens are currently blocked by Anthropic for third-party proxies ([anthropics/claude-code#28091](https://github.com/anthropics/claude-code/issues/28091)). If you hit a 401, use an Anthropic API key instead by adding `"ANTHROPIC_AUTH_TOKEN": "sk-ant-..."` to the env block above.
-
-#### Codex (OpenAI)
+### Codex (OpenAI)
 
 Add to `~/.codex/config.toml` (or `.codex/config.toml` in your project):
 
 ```toml
+model_provider = "hush"
+
 [model_providers.hush]
 base_url = "http://127.0.0.1:4000/v1"
-
-model_provider = "hush"
 ```
 
-Or as an env var: `OPENAI_BASE_URL=http://127.0.0.1:4000/v1 codex`
+### OpenCode (ZhipuAI GLM-5)
 
-#### OpenCode (ZhipuAI GLM-5)
-
-Create `opencode.json` in your **project root** (the folder where you run `opencode`):
+Create `opencode.json` in your project root:
 
 ```json
 {
@@ -96,9 +55,7 @@ Create `opencode.json` in your **project root** (the folder where you run `openc
 }
 ```
 
-Then run `opencode` as normal — it picks up the config automatically.
-
-#### Gemini CLI
+### Gemini CLI
 
 Gemini CLI only supports env vars for endpoint override (no settings file option):
 
@@ -106,32 +63,44 @@ Gemini CLI only supports env vars for endpoint override (no settings file option
 CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000 gemini
 ```
 
-### 4. Verify it works
+### Verify it works
 
-Watch the gateway terminal (Terminal 1). When your AI tool sends a request containing PII, you'll see:
+When your AI tool sends a request containing PII, the hush terminal shows:
 
 ```
 INFO: Redacted sensitive data from request  path="/v1/messages"  tokenCount=2  duration=1
 ```
 
-The AI tool still sees the original data in responses (rehydrated locally). The LLM provider only ever sees tokens like `[USER_EMAIL_f22c5a]`.
-
-## Features
-
-- **Semantic Redaction:** Identifies and masks PII (emails, IPs, secrets, credit cards, phone numbers) using deterministic hash-based tokens (e.g., `[USER_EMAIL_f22c5a]`). Same input always produces the same token.
-- **Local Rehydration:** Restores original values in the LLM's response locally. You see the real data; the cloud provider only sees tokens.
-- **Streaming Support:** SSE-aware rehydration handles tokens split character-by-character across separate JSON events (tested with ZhipuAI GLM-5).
-- **Live Dashboard:** Run with `--dashboard` for a real-time TUI showing PII being blocked.
-- **Zero-Trust:** Local-only processing. PII never leaves your machine. Binds to `127.0.0.1` by default.
-- **Universal Proxy:** One gateway instance handles all providers. Route auto-detection from request path — no configuration needed.
+Your tool still sees the real data (rehydrated locally). The LLM provider only ever sees tokens like `[USER_EMAIL_f22c5a]`.
 
 ## How it Works
 
-1. **Intercept:** Hush sits on your machine as an HTTP proxy between your AI tool and the LLM provider.
-2. **Redact:** Before forwarding, Hush scans the request for PII and swaps matches for deterministic tokens (e.g., `bulat@aictrl.dev` → `[USER_EMAIL_f22c5a]`).
-3. **Vault:** Original values are saved in a local, in-memory `TokenVault` (auto-expires after 1 hour).
-4. **Forward:** The redacted request is sent to the LLM provider. The provider never sees your real data.
-5. **Rehydrate:** When the response comes back, Hush replaces tokens with original values before returning to your tool.
+1. **Intercept** — Hush sits on your machine between your AI tool and the LLM provider.
+2. **Redact** — Before forwarding, it scans for PII and swaps it for deterministic tokens (`bulat@aictrl.dev` → `[USER_EMAIL_f22c5a]`).
+3. **Vault** — Original values are saved in a local, in-memory TokenVault (auto-expires after 1 hour).
+4. **Forward** — The redacted request goes to the provider. They never see your real data.
+5. **Rehydrate** — Responses come back with tokens replaced by originals before reaching your tool.
+
+## Supported Tools
+
+| Tool | Config | Route |
+|------|--------|-------|
+| Claude Code | `~/.claude/settings.json` | `/v1/messages` → Anthropic |
+| Codex | `~/.codex/config.toml` | `/v1/chat/completions` → OpenAI |
+| OpenCode | `opencode.json` | `/api/paas/v4/**` → ZhipuAI |
+| Gemini CLI | `CODE_ASSIST_ENDPOINT` env var | `/v1beta/models/**` → Google |
+| Any tool | Point base URL at hush | `/*` catch-all with auto-detect |
+
+Hush forwards your existing auth headers transparently — no API keys need to be reconfigured.
+
+## Features
+
+- **Semantic Redaction** — Identifies emails, IPs, secrets, credit cards, phone numbers. Deterministic hash-based tokens (same input → same token).
+- **Local Rehydration** — Restores original values in responses locally. You see real data; the provider sees tokens.
+- **Streaming Support** — SSE-aware rehydration handles tokens split across network chunks.
+- **Live Dashboard** — `hush --dashboard` for a real-time TUI showing PII being blocked.
+- **Zero-Trust** — PII never leaves your machine. Binds to `127.0.0.1` by default.
+- **Universal Proxy** — One instance handles all providers simultaneously. Auto-detects from request path.
 
 ## Configuration
 
@@ -139,24 +108,18 @@ The AI tool still sees the original data in responses (rehydrated locally). The 
 |----------|-------------|---------|
 | `PORT` | Gateway listen port | `4000` |
 | `HUSH_HOST` | Bind address | `127.0.0.1` |
-| `HUSH_AUTH_TOKEN` | If set, requires `Authorization: Bearer <token>` or `x-hush-token` header on all requests | — |
+| `HUSH_AUTH_TOKEN` | Require auth on all requests to the gateway itself | — |
 | `HUSH_DASHBOARD` | Enable TUI dashboard | `false` |
-| `DEBUG` | Show vault size in `/health` response | `false` |
+| `DEBUG` | Show vault size in `/health` | `false` |
 
 ## Development
 
 ```bash
-# Run in dev mode (auto-recompile with tsx)
-npm run dev
-
-# Run tests
-npm test
-
-# Run tests in watch mode
-npm run test:watch
-
-# Build
-npm run build
+git clone https://github.com/aictrl-dev/hush.git
+cd hush && npm install
+npm run dev        # dev mode with tsx
+npm test           # run tests
+npm run build      # production build
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -49,27 +49,36 @@ Routes: /v1/messages → Anthropic, /v1/chat/completions → OpenAI, /api/paas/v
 
 ### 3. Point your AI tool at the gateway
 
-Open a **new terminal** for each tool. The gateway handles all providers simultaneously — no restart needed.
+The gateway handles all providers simultaneously — no restart needed. You only need to tell each tool to send requests to `http://127.0.0.1:4000` instead of the provider's API. Hush forwards your existing auth headers transparently — no API keys need to be reconfigured.
 
-#### Claude Code (Anthropic API key)
+#### Claude Code
 
-```bash
-# Terminal 2
-ANTHROPIC_AUTH_TOKEN=sk-ant-api03-YOUR-KEY \
-ANTHROPIC_BASE_URL=http://127.0.0.1:4000 \
-claude
+Add to `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000"
+  }
+}
 ```
 
-> **Note:** Claude Code subscription (OAuth) tokens are currently blocked by Anthropic for third-party proxies. You must use an Anthropic API key. Set `ANTHROPIC_AUTH_TOKEN` (not `ANTHROPIC_API_KEY`) — this tells Claude Code to send it as the `Authorization` header which the gateway forwards.
+Then run `claude` as normal.
+
+> **Note:** Claude Code subscription (OAuth) tokens are currently blocked by Anthropic for third-party proxies ([anthropics/claude-code#28091](https://github.com/anthropics/claude-code/issues/28091)). If you hit a 401, use an Anthropic API key instead by adding `"ANTHROPIC_AUTH_TOKEN": "sk-ant-..."` to the env block above.
 
 #### Codex (OpenAI)
 
-```bash
-# Terminal 3
-OPENAI_API_KEY=sk-YOUR-KEY \
-OPENAI_BASE_URL=http://127.0.0.1:4000/v1 \
-codex
+Add to `~/.codex/config.toml` (or `.codex/config.toml` in your project):
+
+```toml
+[model_providers.hush]
+base_url = "http://127.0.0.1:4000/v1"
+
+model_provider = "hush"
 ```
+
+Or as an env var: `OPENAI_BASE_URL=http://127.0.0.1:4000/v1 codex`
 
 #### OpenCode (ZhipuAI GLM-5)
 
@@ -87,21 +96,14 @@ Create `opencode.json` in your **project root** (the folder where you run `openc
 }
 ```
 
-Then run OpenCode normally — it picks up the config automatically:
-
-```bash
-# Terminal 4
-cd /path/to/your/project
-opencode
-```
+Then run `opencode` as normal — it picks up the config automatically.
 
 #### Gemini CLI
 
+Gemini CLI only supports env vars for endpoint override (no settings file option):
+
 ```bash
-# Terminal 5
-GOOGLE_API_KEY=YOUR-KEY \
-CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000 \
-gemini
+CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000 gemini
 ```
 
 ### 4. Verify it works


### PR DESCRIPTION
## Summary
- Show config-file setup for each tool (settings.json, config.toml, opencode.json) instead of env vars
- Clarify that hush forwards existing auth transparently — no API keys need to be reconfigured
- Note Gemini CLI as the only tool requiring an env var (no config file option)
- Add link to anthropics/claude-code#28091 for OAuth limitation

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)