### PR TITLE
ci: npm publish workflow on version tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,7 @@ jobs:
   publish:
     name: Build, Test & Publish
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build, Test & Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify version matches tag
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          if [ "$PKG_VERSION" != "${{ github.ref_name }}" ]; then
+            echo "::error::Tag ${{ github.ref_name }} does not match package.json version $PKG_VERSION"
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow that publishes to npm when a version tag is pushed
- Triggers on `git tag v*` (e.g., `v0.1.1`)
- Runs full build + test before publishing
- Verifies tag matches `package.json` version (prevents mismatched releases)
- Uses npm provenance for supply chain security

## Usage

After merging, to release:
```bash
# 1. Bump version in package.json
npm version patch   # or minor/major

# 2. Push the tag
git push --follow-tags
```

## Setup required
Add `NPM_TOKEN` secret to the repo: Settings → Secrets → Actions → New repository secret

## Test plan
- [x] Workflow syntax validated
- [ ] Test with first real release after adding NPM_TOKEN secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)