### PR TITLE
docs: team enforcement — commit configs to enforce hush for all devs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ Create `opencode.json` in your project root:
 
 ### Gemini CLI
 
-Gemini CLI only supports env vars for endpoint override (no settings file option):
+Add `.gemini/.env` to your project root (or set the env var directly):
 
 ```bash
-CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000 gemini
+# .gemini/.env
+CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000
 ```
+
+Or: `CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000 gemini`
 
 ### Verify it works
 
@@ -83,8 +86,8 @@ Copy the files from [`examples/team-config/`](examples/team-config/) into your p
 your-project/
 ├── .claude/settings.json     # Claude Code → hush
 ├── .codex/config.toml        # Codex → hush
-├── opencode.json             # OpenCode → hush
-└── .env                      # Gemini CLI → hush (add CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000)
+├── .gemini/.env              # Gemini CLI → hush
+└── opencode.json             # OpenCode → hush
 ```
 
 **Claude Code** — `.claude/settings.json`:
@@ -117,7 +120,7 @@ base_url = "http://127.0.0.1:4000/v1"
 }
 ```
 
-**Gemini CLI** — add to your `.env`:
+**Gemini CLI** — `.gemini/.env`:
 ```
 CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000
 ```
@@ -139,7 +142,7 @@ Each developer just needs `hush` running locally. All AI tools in the project wi
 | Claude Code | `~/.claude/settings.json` | `/v1/messages` → Anthropic |
 | Codex | `~/.codex/config.toml` | `/v1/chat/completions` → OpenAI |
 | OpenCode | `opencode.json` | `/api/paas/v4/**` → ZhipuAI |
-| Gemini CLI | `CODE_ASSIST_ENDPOINT` env var | `/v1beta/models/**` → Google |
+| Gemini CLI | `.gemini/.env` | `/v1beta/models/**` → Google |
 | Any tool | Point base URL at hush | `/*` catch-all with auto-detect |
 
 Hush forwards your existing auth headers transparently — no API keys need to be reconfigured.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,57 @@ INFO: Redacted sensitive data from request  path="/v1/messages"  tokenCount=2  d
 
 Your tool still sees the real data (rehydrated locally). The LLM provider only ever sees tokens like `[USER_EMAIL_f22c5a]`.
 
+## Enforce for Your Team
+
+Commit config files to your repo so every developer automatically routes through hush — no manual setup per person.
+
+Copy the files from [`examples/team-config/`](examples/team-config/) into your project root:
+
+```
+your-project/
+├── .claude/settings.json     # Claude Code → hush
+├── .codex/config.toml        # Codex → hush
+├── opencode.json             # OpenCode → hush
+└── .env                      # Gemini CLI → hush (add CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000)
+```
+
+**Claude Code** — `.claude/settings.json`:
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000"
+  }
+}
+```
+
+**Codex** — `.codex/config.toml`:
+```toml
+model_provider = "hush"
+
+[model_providers.hush]
+base_url = "http://127.0.0.1:4000/v1"
+```
+
+**OpenCode** — `opencode.json`:
+```json
+{
+  "provider": {
+    "zai-coding-plan": {
+      "options": {
+        "baseURL": "http://127.0.0.1:4000/api/coding/paas/v4"
+      }
+    }
+  }
+}
+```
+
+**Gemini CLI** — add to your `.env`:
+```
+CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000
+```
+
+Each developer just needs `hush` running locally. All AI tools in the project will route through it automatically.
+
 ## How it Works
 
 1. **Intercept** — Hush sits on your machine between your AI tool and the LLM provider.

--- a/examples/team-config/.claude/settings.json
+++ b/examples/team-config/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://127.0.0.1:4000"
+  }
+}

--- a/examples/team-config/.codex/config.toml
+++ b/examples/team-config/.codex/config.toml
@@ -1,0 +1,4 @@
+model_provider = "hush"
+
+[model_providers.hush]
+base_url = "http://127.0.0.1:4000/v1"

--- a/examples/team-config/.env.hush
+++ b/examples/team-config/.env.hush
@@ -1,0 +1,2 @@
+# Gemini CLI — add to your project's .env file
+CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000

--- a/examples/team-config/.env.hush
+++ b/examples/team-config/.env.hush
@@ -1,2 +1,0 @@
-# Gemini CLI — add to your project's .env file
-CODE_ASSIST_ENDPOINT=http://127.0.0.1:4000

--- a/examples/team-config/opencode.json
+++ b/examples/team-config/opencode.json
@@ -1,0 +1,9 @@
+{
+  "provider": {
+    "zai-coding-plan": {
+      "options": {
+        "baseURL": "http://127.0.0.1:4000/api/coding/paas/v4"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `examples/team-config/` with ready-to-copy config files for all four tools
- Add "Enforce for Your Team" section to README showing how to commit per-project configs
- Every developer who clones the repo automatically routes through hush — zero manual setup

## Config files
| Tool | File | Committable |
|------|------|-------------|
| Claude Code | `.claude/settings.json` | Yes |
| Codex | `.codex/config.toml` | Yes |
| OpenCode | `opencode.json` | Yes |
| Gemini CLI | `.env` (`CODE_ASSIST_ENDPOINT`) | Yes |

## Test plan
- [x] All 30 tests pass
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)